### PR TITLE
Fixing SSH key generation to address bug #31

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.mod
 *.sum
 .DS_Store
+*.exe
 ad-aksctl.code-workspace

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -51,7 +51,7 @@ var clusterCmd = &cobra.Command{
 
 		/*
 			viper default value will be prior than Flag default
-			so value selection priority oerder is
+			so value selection priority order is
 				- Flag Value
 				- Config File
 				- Vipro Default

--- a/coreaksctl/cluster.go
+++ b/coreaksctl/cluster.go
@@ -14,6 +14,12 @@ func CreateCluster(clusterName string, resourceGroupName string, extraflags []st
 	fmt.Println("---------------------------------")
 	//Create AKS Cluster
 	var args = []string{"aks", "create", "--name", clusterName, "--resource-group", resourceGroupName}
+	//handle the SSH keys generation in case of basic usage or the key value is not present on the config file
+	fmt.Println(extraflags)
+	_, found := Find(extraflags, "ssh-key-value")
+	if !found {
+		extraflags = append(extraflags, "--generate-ssh-keys")
+	}
 	args = append(args, extraflags...)
 	cmd := exec.Command("az", args...)
 	var out bytes.Buffer
@@ -104,4 +110,15 @@ func GetCluster(resourceGroupName string) {
 		return
 	}
 	fmt.Println("Result: " + out.String())
+}
+
+// Find takes a slice and looks for an element in it. If found it will
+// return it's key, otherwise it will return -1 and a bool of false.
+func Find(slice []string, val string) (int, bool) {
+	for i, item := range slice {
+		if item == val {
+			return i, true
+		}
+	}
+	return -1, false
 }


### PR DESCRIPTION
Fixing issue #31 

- Added a check for the extraflags string array to validate that ssh-key-value is present and if not, "--generate-ssh-keys" will be appended to autogenerate SSH keys
