### PR TITLE
Fix golint warnings

### DIFF
--- a/cmd/addon.go
+++ b/cmd/addon.go
@@ -1,4 +1,4 @@
-/*
+/*Package cmd is used for command line
 Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -1,4 +1,4 @@
-/*
+/*Package cmd is used for command line
 Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,4 +1,4 @@
-/*
+/*Package cmd is used for command line
 Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,4 +1,4 @@
-/*
+/*Package cmd is used for command line
 Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/disk.go
+++ b/cmd/disk.go
@@ -1,4 +1,4 @@
-// /*
+///*Package cmd is used for command line
 // Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,4 +1,4 @@
-/*
+/*Package cmd is used for command line
 Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,4 +1,4 @@
-/*
+/*Package cmd is used for command line
 Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1,4 +1,4 @@
-/*
+/*Package cmd is used for command line
 Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/nodepool.go
+++ b/cmd/nodepool.go
@@ -1,4 +1,4 @@
-// /*
+// /*Package cmd is used for command line
 // Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/resourcegroup.go
+++ b/cmd/resourcegroup.go
@@ -1,4 +1,4 @@
-/*
+/*Package cmd is used for command line
 Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-/*
+/*Package cmd is used for command line
 Copyright © 2019 Anoop Lekshmanan anoopl@adfolks.com
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -1,4 +1,4 @@
-/*
+/*Package cmd is used for command line
 Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,4 +1,4 @@
-/*
+/*Package cmd is used for command line
 Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -1,4 +1,4 @@
-/*
+/*Package cmd is used for command line
 Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,4 +1,4 @@
-/*
+/*Package cmd is used for command line
 Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/vnet.go
+++ b/cmd/vnet.go
@@ -1,4 +1,4 @@
-// /*
+// /*Package cmd is used for command line
 // Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The golint warning "package comment should be of the form 'Package cmd ...'"was fixed.