### PR TITLE
Fix golint warnings

### DIFF
--- a/cmd/disk.go
+++ b/cmd/disk.go
@@ -1,4 +1,4 @@
-///*Package cmd is used for command line
+//Package cmd is used for command line
 // Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// */
+//
 package cmd
 
 import (

--- a/cmd/nodepool.go
+++ b/cmd/nodepool.go
@@ -1,4 +1,4 @@
-// /*Package cmd is used for command line
+//Package cmd is used for command line
 // Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// */
+//
 package cmd
 
 import (

--- a/cmd/resourcegroup.go
+++ b/cmd/resourcegroup.go
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package cmd
 
 import (

--- a/cmd/vnet.go
+++ b/cmd/vnet.go
@@ -1,4 +1,4 @@
-// /*Package cmd is used for command line
+//Package cmd is used for command line
 // Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// */
+//
 package cmd
 
 import (

--- a/pkg/ctl/addon/install.go
+++ b/pkg/ctl/addon/install.go
@@ -36,7 +36,7 @@ func InstallAddon(chartName string, repoName string) {
 	emoji.Println(":beer: Cheers!!!")
 }
 
-//ChekHelm will check the version
+//CheckHelm checks whether the latest Helm version is installed or not
 func CheckHelm() bool {
 	cmd := exec.Command("helm", "version")
 	var out bytes.Buffer

--- a/pkg/ctl/cluster/cluster.go
+++ b/pkg/ctl/cluster/cluster.go
@@ -45,7 +45,7 @@ func CreateCluster(clusterName string, resourceGroupName string, extraflags []st
 	emoji.Println(":beer: Cheers!!!")
 }
 
-//GetClusterCredentials
+//GetClusterCredentials  gives the cluster credentials
 func GetClusterCredentials(clusterName string, resourceGroupName string) {
 	b := wow.New(os.Stdout, spin.Get(spin.Dots), "Fetching credentials")
 	b.Start()
@@ -89,7 +89,7 @@ func DeleteCluster(clusterName string, resourceGroupName string) {
 	color.Green("Cluster Deleted")
 }
 
-//UpdateClustr update a cluster
+//UpdateCluster updates a cluster
 func UpdateCluster(clusterName string, resourceGroupName string) {
 	a := wow.New(os.Stdout, spin.Get(spin.Dots), "Updating your k8s Cluster")
 	a.Start()

--- a/pkg/ctl/nodepool/nodepool.go
+++ b/pkg/ctl/nodepool/nodepool.go
@@ -55,6 +55,7 @@ func DeleteNodePool(clusterName string, nodePoolName string, rgroupName string) 
 	color.Green("Nodepool Deleted")
 }
 
+//ScaleNodePool is used to set the number of nodes in the nodepool
 func ScaleNodePool(clusterName string, nodePoolName string, rgroupName string) {
 	a := wow.New(os.Stdout, spin.Get(spin.Dots), "Scaling nodepool : "+nodePoolName)
 	a.Start()
@@ -75,7 +76,7 @@ func ScaleNodePool(clusterName string, nodePoolName string, rgroupName string) {
 	fmt.Println("Result: " + out.String())
 }
 
-//UpdateNodePool
+//UpdateNodePool updates a nodepool
 func UpdateNodePool(clusterName string, nodePoolName string, rgroupName string) {
 	a := wow.New(os.Stdout, spin.Get(spin.Dots), "Updating nodepool : "+nodePoolName)
 	a.Start()

--- a/pkg/ctl/resourcegroup/resourcegroup.go
+++ b/pkg/ctl/resourcegroup/resourcegroup.go
@@ -32,7 +32,7 @@ func CreateResourceGroup(rgroupName string, rgroupRegion string) {
 	emoji.Println(":beer: Cheers!!!")
 }
 
-//CheckResoureGroup will check whether a resource group exit or not
+//CheckResourceGroup will check whether a resource group exit or not
 func CheckResourceGroup(rgroupName string) bool {
 	cmd := exec.Command("az", "group", "exists", "-n", rgroupName)
 	var check bool
@@ -77,7 +77,7 @@ func DeleteResourceGroup(rgroupName string) {
 	color.Green("Resource group Deleted")
 }
 
-//UpdateResourceGroup
+//UpdateResourceGroup updates a resource group
 func UpdateResourceGroup(rgroupName string) {
 	//Update AKS ResourceGroup
 	a := wow.New(os.Stdout, spin.Get(spin.Dots), "Updating resource group : "+rgroupName)

--- a/pkg/ctl/utils/util.go
+++ b/pkg/ctl/utils/util.go
@@ -59,7 +59,7 @@ func stringToMap(data string) []map[string]interface{} {
 	return value
 }
 
-//FilterStringMap
+//FilterStringMap will filter the map
 func FilterStringMap(data string, key string) []string {
 	mapdata := stringToMap(data)
 	var slice []string

--- a/pkg/ctl/vnet/vnet.go
+++ b/pkg/ctl/vnet/vnet.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-//CreatVNet will create vnet
+//CreateVNet will create a vnet
 func CreateVNet(vNetName string, rgroupName string) {
 	a := wow.New(os.Stdout, spin.Get(spin.Dots), "Creating virtual network : "+vNetName)
 	a.Start()


### PR DESCRIPTION
Fixed following warnings
- package comment should be of the form "Package cmd ...".
- exported function warning is fixed.
- package comment is detached; there should be no blank lines between it and the package statement.