### PR TITLE
Fix golint and gofmt warnings

### DIFF
--- a/cmd/disk.go
+++ b/cmd/disk.go
@@ -1,4 +1,4 @@
-//Package cmd is used for command line
+/*Package cmd is used for command line
 // Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
+*/
 package cmd
 
 import (

--- a/cmd/nodepool.go
+++ b/cmd/nodepool.go
@@ -1,4 +1,4 @@
-//Package cmd is used for command line
+/*Package cmd is used for command line
 // Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
+*/
 package cmd
 
 import (

--- a/cmd/vnet.go
+++ b/cmd/vnet.go
@@ -1,4 +1,4 @@
-//Package cmd is used for command line
+/*Package cmd is used for command line
 // Copyright © 2019 NAME HERE <EMAIL ADDRESS>
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
+*/
 package cmd
 
 import (

--- a/pkg/ctl/addon/uninstall.go
+++ b/pkg/ctl/addon/uninstall.go
@@ -28,7 +28,7 @@ func UninstallAddon(chartName string) {
 	err := cmd.Run()
 	if err != nil {
 		fmt.Println(fmt.Sprint(err) + ": " + stderr.String())
-	}else{
+	} else {
 		a.PersistWith(spin.Spinner{}, "....")
 		color.Green("Addon uninstalled")
 		emoji.Println(":beer: Cheers!!!")


### PR DESCRIPTION
Fixed following warnings:

- The file is not gofmted with -s.
- The package comment should be of the form "Package cmd ...".