### PR TITLE
add instructions to install on windows using chocolatey

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ curl --silent --location "https://github.com/adfolks/aksctl/releases/download/$r
 sudo mv /tmp/aksctl /usr/local/bin
 ```
 
+#### Option 3:
+To install aksctl on windows using chocolatey, run:
+```bash
+choco install aksctl
+```
+
+
 ## Basic usage
  A default cluster can be created by running:
   ```bash


### PR DESCRIPTION
Instructions were added in the README.md for windows users to install aksctl using chocolatey.